### PR TITLE
fix: resolve VirtualizedList nesting warnings

### DIFF
--- a/src/components/DecksMultiSelect.tsx
+++ b/src/components/DecksMultiSelect.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useState } from 'react';
-import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import type { Deck, DecksMultiSelectProps } from '../interfaces';
 import { Typography } from './ui/Typography';
@@ -102,11 +102,10 @@ const DecksMultiSelect: React.FC<DecksMultiSelectProps> = ({
       {isVisible && (
         <View>
           {selectedSubject === null ? (
-            <FlatList
-              data={subjects}
-              keyExtractor={(item) => item}
-              renderItem={({ item, index }) => (
+            <ScrollView style={styles.list}>
+              {subjects.map((item, index) => (
                 <TouchableOpacity
+                  key={item}
                   onPress={() => setSelectedSubject(item)}
                   style={[
                     styles.item,
@@ -121,16 +120,14 @@ const DecksMultiSelect: React.FC<DecksMultiSelectProps> = ({
                     {item}
                   </Typography>
                 </TouchableOpacity>
-              )}
-              style={styles.list}
-            />
+              ))}
+            </ScrollView>
           ) : (
             <View>
-              <FlatList
-                data={filteredDecks}
-                keyExtractor={(item) => item.deck_id.toString()}
-                renderItem={({ item, index }) => (
+              <ScrollView style={styles.list}>
+                {filteredDecks.map((item, index) => (
                   <TouchableOpacity
+                    key={item.deck_id.toString()}
                     onPress={() => handleSelectDeck(item)}
                     style={[
                       styles.item,
@@ -147,9 +144,8 @@ const DecksMultiSelect: React.FC<DecksMultiSelectProps> = ({
                       {item.deck_name}
                     </Typography>
                   </TouchableOpacity>
-                )}
-                style={styles.list}
-              />
+                ))}
+              </ScrollView>
               <TouchableOpacity
                 onPress={() => setSelectedSubject(null)}
                 style={styles.backButton}

--- a/src/components/UsersDropdown.tsx
+++ b/src/components/UsersDropdown.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useState } from 'react';
-import { FlatList, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '../context/ThemeContext';
 import { useUser } from '../context/UserContext';
 import type { User, UsersDropdownProps } from '../interfaces';
@@ -65,11 +65,10 @@ const UsersDropdown: React.FC<UsersDropdownProps> = ({
         </Typography>
       </TouchableOpacity>
       {isVisible && (
-        <FlatList
-          data={users}
-          keyExtractor={(item) => item.user_id.toString()}
-          renderItem={({ item, index }) => (
+        <ScrollView style={styles.list}>
+          {users.map((item, index) => (
             <TouchableOpacity
+              key={item.user_id.toString()}
               onPress={() => handleSelectUser(item)}
               style={[
                 styles.item,
@@ -84,9 +83,8 @@ const UsersDropdown: React.FC<UsersDropdownProps> = ({
                 {item.user_name}
               </Typography>
             </TouchableOpacity>
-          )}
-          style={styles.list}
-        />
+          ))}
+        </ScrollView>
       )}
     </View>
   );

--- a/src/components/ui/AchievementGallery/AchievementGallery.tsx
+++ b/src/components/ui/AchievementGallery/AchievementGallery.tsx
@@ -269,7 +269,7 @@ export const AchievementGallery: React.FC<AchievementGalleryProps> = ({
         </View>
       )}
 
-      <ScrollView showsVerticalScrollIndicator={false}>
+      <View>
         {filteredAchievements.length > 0 ? (
           <View style={styles.achievementsGrid}>
             {filteredAchievements.map(renderAchievement)}
@@ -289,7 +289,7 @@ export const AchievementGallery: React.FC<AchievementGalleryProps> = ({
             </Typography>
           </View>
         )}
-      </ScrollView>
+      </View>
     </View>
   );
 };

--- a/src/components/ui/StatsDashboard/StatsDashboard.tsx
+++ b/src/components/ui/StatsDashboard/StatsDashboard.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import { useAnalytics } from '../../../context/AnalyticsContext';
 import { AnalyticsChart } from '../AnalyticsChart';
 import { Button } from '../Button';
@@ -79,7 +79,7 @@ export const StatsDashboard: React.FC<StatsDashboardProps> = ({ userId }) => {
   );
 
   return (
-    <ScrollView className="flex-1 p-4" showsVerticalScrollIndicator={false}>
+    <View className="flex-1 p-4">
       {/* Summary Stats */}
       <View className="mb-6">
         <Typography variant="heading2" className="mb-4 text-center">
@@ -249,6 +249,6 @@ export const StatsDashboard: React.FC<StatsDashboardProps> = ({ userId }) => {
           ))
         )}
       </View>
-    </ScrollView>
+    </View>
   );
 };


### PR DESCRIPTION
## Summary
- Replace `FlatList` with `ScrollView` + `.map()` in dropdown components (`UsersDropdown`, `DecksMultiSelect`) to avoid nesting VirtualizedList inside ScrollView
- Replace inner `ScrollView` with `View` in components (`AchievementGallery`, `StatsDashboard`) that are rendered inside parent ScrollViews

## Changes
| File | Change |
|------|--------|
| `src/components/UsersDropdown.tsx` | Replaced `FlatList` with `ScrollView` + `.map()` |
| `src/components/DecksMultiSelect.tsx` | Replaced both `FlatList` components with `ScrollView` + `.map()` |
| `src/components/ui/AchievementGallery/AchievementGallery.tsx` | Replaced inner vertical `ScrollView` with `View` |
| `src/components/ui/StatsDashboard/StatsDashboard.tsx` | Replaced `ScrollView` wrapper with `View` |

## Test plan
- [ ] Verify VirtualizedList nesting warnings no longer appear in console
- [ ] Test UsersDropdown scrolling behavior in ProfileScreen and FlashCardScreen
- [ ] Test DecksMultiSelect subject/deck selection and scrolling
- [ ] Verify AchievementGallery renders correctly in ProfileScreen
- [ ] Verify StatsDashboard displays analytics without scroll issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)